### PR TITLE
Fix issue #13 : Vessels don't rotate until unpacked once, and don't rotate at all when KSPCF is installed

### DIFF
--- a/Source/Data.cs
+++ b/Source/Data.cs
@@ -16,6 +16,7 @@ namespace PersistentRotation
             //General
             public Vessel vessel;
             public Vector3 storedAngularMomentum;
+            public Vector3 storedMOI;
             public Vector3 planetariumRight;
 
             //Cached data for when going off rails
@@ -117,6 +118,7 @@ namespace PersistentRotation
                 {
                     ConfigNode cn_vessel = save.AddNode(v.vessel.id.ToString());
                     cn_vessel.AddValue("MOMENTUM", KSPUtil.WriteVector(v.storedAngularMomentum));
+                    cn_vessel.AddValue("MOI", KSPUtil.WriteVector(v.storedMOI));
                     cn_vessel.AddValue("PLANETARIUM_RIGHT", KSPUtil.WriteVector(v.planetariumRight));
 
                     cn_vessel.AddValue("MJMODE", ((int)(v.mjMode)).ToString());
@@ -224,6 +226,7 @@ namespace PersistentRotation
                 {
                     Debug.Log("[PR] Found node for vessel " + v.vessel.vesselName);
                     v.storedAngularMomentum = KSPUtil.ParseVector3(cn_vessel.GetValue("MOMENTUM"));
+                    v.storedMOI = KSPUtil.ParseVector3(cn_vessel.GetValue("MOI") ?? "0,0,0");
                     v.planetariumRight = KSPUtil.ParseVector3(cn_vessel.GetValue("PLANETARIUM_RIGHT"));
                     v.mjMode = MechJebWrapper.saTargetMap[int.Parse(cn_vessel.GetValue("MJMODE"))];
                     v.rtMode = RemoteTechWrapper.acFlightModeMap[int.Parse(cn_vessel.GetValue("RTMODE"))];

--- a/Source/Main.cs
+++ b/Source/Main.cs
@@ -311,10 +311,10 @@ namespace PersistentRotation
         }
         private void OnVesselGoOnRails(Vessel vessel)
         {
-            //Nothing to do here
+            // MOI needs to be saved before packing / going on rails, as the value won't be available after that
+            data.FindPRVessel(vessel).storedMOI = vessel.MOI;
 
             //DEBUG
-            //Data.PRVessel v = data.FindPRVessel(vessel);
             //KSPLog.print(string.Format("GoOnRails angvel: {0}, stored: {1}", vessel.angularVelocityD, v.storedAngularMomentum));
         }
         private void OnVesselGoOffRails(Vessel vessel)
@@ -358,9 +358,9 @@ namespace PersistentRotation
         {
             Vector3 _angularVelocity = Vector3.zero;
 
-            _angularVelocity.x = v.storedAngularMomentum.x / v.vessel.MOI.x;
-            _angularVelocity.y = v.storedAngularMomentum.y / v.vessel.MOI.y;
-            _angularVelocity.z = v.storedAngularMomentum.z / v.vessel.MOI.z;
+            _angularVelocity.x = v.storedMOI.x == 0f ? 0f : v.storedAngularMomentum.x / v.storedMOI.x;
+            _angularVelocity.y = v.storedMOI.y == 0f ? 0f : v.storedAngularMomentum.y / v.storedMOI.y;
+            _angularVelocity.z = v.storedMOI.z == 0f ? 0f : v.storedAngularMomentum.z / v.storedMOI.z;
 
             if (v.vessel.situation != Vessel.Situations.LANDED && v.vessel.situation != Vessel.Situations.SPLASHED && v.vessel.situation != Vessel.Situations.PRELAUNCH)
                 v.vessel.SetRotation(Quaternion.AngleAxis(_angularVelocity.magnitude * TimeWarp.CurrentRate, v.vessel.ReferenceTransform.rotation * _angularVelocity) * v.vessel.transform.rotation, true);


### PR DESCRIPTION
See issue #13

When spinning while packed / on rails, the `MOI` is now applied from a persisted value on the `PRVessel` data structure, saved just before the vessel is packed.

Previously, PR was using the `Vessel.MOI` field, which isn't computed until the vessel has been unpacked at least once, meaning vessels loaded outside of unpacking range weren't spinning. The issue extended to every packed vessel when KSPCF is installed, as KSPCF is fixing a bug restoring the intended stock API behavior preventing stale/incoherent MOI values from being available (see https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/277)

Note that I did not test the changes extensively with the more advanced PR features as I don't even know what they are supposed to do, but from a code review the changes shouldn't have other side effects.